### PR TITLE
gift card generator

### DIFF
--- a/.env.sepolia
+++ b/.env.sepolia
@@ -8,5 +8,5 @@ TRANSACTION_URL=https://sepolia.etherscan.io/tx/{{hash}}
 TOKEN_SYMBOL=BOB
 SHIELDED_TOKEN_SYMBOL=shBOB
 DELEGATED_PROVER_URL=''
-CLOUD_API_ENDPOINT='http://45.77.217.163'
-GIFTCARD_REDEMPTION_URL_PREFIX='https://staging--zkbob.netlify.app/redeem?code='
+CLOUD_API_ENDPOINT='http://45.77.217.163:8701'
+GIFTCARD_REDEMPTION_URL='https://staging--zkbob.netlify.app'

--- a/.env.sepolia
+++ b/.env.sepolia
@@ -8,3 +8,5 @@ TRANSACTION_URL=https://sepolia.etherscan.io/tx/{{hash}}
 TOKEN_SYMBOL=BOB
 SHIELDED_TOKEN_SYMBOL=shBOB
 DELEGATED_PROVER_URL=''
+CLOUD_API_ENDPOINT='http://45.77.217.163'
+GIFTCARD_REDEMPTION_URL_PREFIX='https://staging--zkbob.netlify.app/redeem?code='

--- a/README.md
+++ b/README.md
@@ -130,3 +130,7 @@ Suppose you already done local running and set appropriated parameters and setti
 `help` display CLI commands list
 
 `tutorial` print usage example
+
+## Gift cards commands
+
+`gift-cards <alias> <quantity> <balance> <token>` generates `<quantity>` cloud accounts with `<alias>_index` description using `<token>` to access admin API; generate QR codes to login into each account; makes shielded transfer of `<balance>` shBob to each created account; generates a report with account keys, redemptions urls and cloud Ids

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "env.js"
   ],
   "dependencies": {
+    "@ribpay/qr-code-generator": "^1.0.6",
     "@truffle/hdwallet-provider": "2.0.9",
     "assert": "^2.0.0",
     "bip39-light": "^1.0.7",
@@ -27,6 +28,7 @@
     "https-browserify": "^1.0.0",
     "jquery": "^3.5.1",
     "jquery.terminal": "2.34.0",
+    "jszip": "^3.10.1",
     "os-browserify": "^0.3.0",
     "path-browserify": "^1.0.1",
     "process": "^0.11.10",

--- a/src/account.ts
+++ b/src/account.ts
@@ -344,6 +344,9 @@ export default class Account {
         return await this.zpClient.getLimits(TOKEN_ADDRESS, addr, false);
     }
 
+    public async minTxAmount(): Promise<bigint> {
+        return await this.zpClient.minTxAmount();
+     }
     public async getMaxAvailableTransfer(amount: bigint, fee: bigint): Promise<bigint> {
         return await this.zpClient.calcMaxAvailableTransfer(TOKEN_ADDRESS, false);
     }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -859,7 +859,11 @@ export async function generateGiftCards(prefix: string, quantity: string, cardBa
             const url = redemptionUrl(sk, treeIndex);
             const svg = qrcode(url);
             giftCards.push(new GiftCard(alias, cloudId, sk, address, svg, url));
-        }    
+            if (Number(quantity) > 1) {
+                this.update(-1, `Generating accounts...[${cardIndex + 1}/${Number(quantity)}]`);
+            }
+        }
+        this.update(-1, `Generating account${Number(quantity) > 1 ? 's' : ''}...[[;green;]OK]`);
     
         let zipUrl = await zip(giftCards);
         this.echo(`Cards generated, [[!;;;;${zipUrl}]this archive] contains QR codes and summary report.\nSending funds ...`);    

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -824,6 +824,7 @@ export async function generateGiftCards(prefix: string, quantity: string, cardBa
     let giftCards: GiftCard[] = [];
     const treeIndex = (await this.account.getPoolTreeState()).index
     try {
+        this.echo(`Generating account${Number(quantity) > 1 ? 's' : ''}...`);
         for (let cardIndex = 0; cardIndex < Number(quantity); cardIndex++) {
             const alias = `${prefix}_${cardIndex}`;
             const body = JSON.stringify({ "description": `${alias}` });

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -877,7 +877,7 @@ export async function generateGiftCards(prefix: string, quantity: string, cardBa
         
     } catch (error) {
         
-        this.echo("process failed with error: ", error)
+        this.echo(`Process failed with error: [[;red;]${error.message}]`);
 
     }
     

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,6 +66,7 @@ const COMMANDS: { [key: string]: [(...args) => void, string, string] } = {
   'support-id': [c.getSupportId, '', 'get the client support id'],
   'version': [ c.getVersion, '', 'get console and relayer versions'
   ],
+  'gift-cards':[c.generateGiftCards,'<url> <prefix> <quantity> <balance> <token>','generate gift cards'],
   'environment': [
     function () {
       this.echo(`Network: ${NETWORK}`);
@@ -183,6 +184,7 @@ jQuery(async function ($) {
         callback(Object.keys(COMMANDS));
       }
     },
+    anyLinks:true,
     historyFilter: function (command) {
       return PRIVATE_COMMANDS.indexOf(command) == -1;
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,7 @@ const COMMANDS: { [key: string]: [(...args) => void, string, string] } = {
   'support-id': [c.getSupportId, '', 'get the client support id'],
   'version': [ c.getVersion, '', 'get console and relayer versions'
   ],
-  'gift-cards':[c.generateGiftCards,'<url> <prefix> <quantity> <balance> <token>','generate gift cards'],
+  'gift-cards':[c.generateGiftCards,'<alias> <quantity> <balance> <token>','generate gift cards'],
   'environment': [
     function () {
       this.echo(`Network: ${NETWORK}`);

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -40,6 +40,8 @@ module.exports = merge(common, {
             TOKEN_SYMBOL: null,
             SHIELDED_TOKEN_SYMBOL: null,
             DELEGATED_PROVER_URL: null,
+            CLOUD_API_ENDPOINT:null,
+            GIFTCARD_REDEMPTION_URL:null
         }),
     ]
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1439,6 +1439,11 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
 
+"@ribpay/qr-code-generator@^1.0.6":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@ribpay/qr-code-generator/-/qr-code-generator-1.0.6.tgz#b0e5b43af9c1a1fe8fad8c089bdbd1af23e8db1f"
+  integrity sha512-Pucebv9RyNL2+xntvCJ7TQiWoC9hsEFkMlV0KMVnPXzKVn7mF3V+c/2A8L/iHm8QnZMtzQjb5cXJJdaigeoVjg==
+
 "@scure/base@1.0.0", "@scure/base@~1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.0.0.tgz#109fb595021de285f05a7db6806f2f48296fcee7"
@@ -5308,6 +5313,11 @@ immediate@^3.2.3:
   resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.3.0.tgz#1aef225517836bcdf7f2a2de2600c79ff0269266"
   integrity sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q==
 
+immediate@~3.0.5:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
+  integrity sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==
+
 import-fresh@^3.0.0, import-fresh@^3.2.1:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"
@@ -5862,6 +5872,16 @@ jsprim@^1.2.2:
     json-schema "0.4.0"
     verror "1.10.0"
 
+jszip@^3.10.1:
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/jszip/-/jszip-3.10.1.tgz#34aee70eb18ea1faec2f589208a157d1feb091c2"
+  integrity sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==
+  dependencies:
+    lie "~3.3.0"
+    pako "~1.0.2"
+    readable-stream "~2.3.6"
+    setimmediate "^1.0.5"
+
 keccak@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/keccak/-/keccak-2.1.0.tgz#734ea53f2edcfd0f42cdb8d5f4c358fef052752b"
@@ -5991,6 +6011,13 @@ libzkbob-rs-wasm-web@0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/libzkbob-rs-wasm-web/-/libzkbob-rs-wasm-web-0.9.0.tgz#8bf6198382bbdd3750ee7386b0ffc32ea2be09c3"
   integrity sha512-H9a6QYuR7ZXhwSOstJWAobJh128xV5EI66wQSw/oMFjGvMgD8JuClVw/eDLV+WDncFuT7p2OPnAPwBdeehVx7A==
+
+lie@~3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/lie/-/lie-3.3.0.tgz#dcf82dee545f46074daf200c7c1c5a08e0f40f6a"
+  integrity sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==
+  dependencies:
+    immediate "~3.0.5"
 
 lightningcss-darwin-arm64@1.17.1:
   version "1.17.1"
@@ -6941,6 +6968,11 @@ pako@^2.0.4:
   resolved "https://registry.yarnpkg.com/pako/-/pako-2.1.0.tgz#266cc37f98c7d883545d11335c00fbd4062c9a86"
   integrity sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==
 
+pako@~1.0.2:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
+  integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
+
 param-case@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/param-case/-/param-case-3.0.4.tgz#7d17fe4aa12bde34d4a77d91acfb6219caad01c5"
@@ -7464,7 +7496,7 @@ readable-stream@^1.0.33:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.2.9:
+readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.2.9, readable-stream@~2.3.6:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==


### PR DESCRIPTION
### new command to generate a batch of gift cards:
syntax: `gift-cards <alias> <quantity> <balance> <token>`
example: `gift-cards denver3 1 ^0.2 cloud_admin_token`

The flow:
1. Create cloud account 
2. Generate receiving address
3. Export spending key
4. Generate QR codes and summary
5. Initiate a transfer ( or several)  to fund created accounts

Summary can be useful to monitor or sweep cards balances and for troubleshooting

###  new env variables
CLOUD_API_ENDPOINT - `protocol://host:port` for cloud wallet api eg http://localhost:8001
GIFTCARD_REDEMPTION_URL - `protocol://host:port` for client web app eg https://staging--zkbob.netlify.app

