### PR TITLE
Ability to add custom address prefix

### DIFF
--- a/client-config-full.json
+++ b/client-config-full.json
@@ -158,17 +158,6 @@
         }
     },
 
-    "extraPrefixes": [
-        {
-            "poolId": 16776966,
-            "prefix": "zkbob_shasta"
-        },
-        {
-            "poolId": 16776967,
-            "prefix": "zkbob_nile"
-        }
-    ],
-
     "globalSnarks": {
         "transferParamsUrl": "./assets/transfer_params.bin",
         "transferVkUrl": "./assets/transfer_verification_key.json"

--- a/client-config-full.json
+++ b/client-config-full.json
@@ -158,6 +158,17 @@
         }
     },
 
+    "extraPrefixes": [
+        {
+            "poolId": 16776966,
+            "prefix": "zkbob_shasta"
+        },
+        {
+            "poolId": 16776967,
+            "prefix": "zkbob_nile"
+        }
+    ],
+
     "globalSnarks": {
         "transferParamsUrl": "./assets/transfer_params.bin",
         "transferVkUrl": "./assets/transfer_verification_key.json"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "tslib": "^2.3.1",
     "uuid": "^9.0.0",
     "web3": "^1.7.1",
-    "zkbob-client-js": "file:../zkbob-client-js",
+    "zkbob-client-js": "5.5.0-beta",
     "zkbob-support-js": "1.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "tslib": "^2.3.1",
     "uuid": "^9.0.0",
     "web3": "^1.7.1",
-    "zkbob-client-js": "5.4.0",
+    "zkbob-client-js": "file:../zkbob-client-js",
     "zkbob-support-js": "1.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "tslib": "^2.3.1",
     "uuid": "^9.0.0",
     "web3": "^1.7.1",
-    "zkbob-client-js": "5.5.0-beta",
+    "zkbob-client-js": "5.5.0-beta1",
     "zkbob-support-js": "1.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zkbob-console",
-  "version": "3.8.0",
+  "version": "3.9.0",
   "license": "MIT",
   "author": "Dmitry Vdovin <voidxnull@gmail.com>",
   "homepage": "https://github.com/zkBob/zkbob-console",

--- a/src/account.ts
+++ b/src/account.ts
@@ -74,6 +74,7 @@ export class Account {
         this.config = {
             pools: env.pools,
             chains: env.chains,
+            extraPrefixes: env.extraPrefixes,
             snarkParams: env.globalSnarks,
             snarkParamsSet: env.snarkParamsSet,
             supportId: this.supportId,

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -110,13 +110,19 @@ export async function genShieldedAddressUniversal(number: string) {
 }
 
 export async function shieldedAddressInfo(shieldedAddress: string) {
+    this.echo('Validating ...');
+    const isValid = await account(this).verifyShieldedAddress(shieldedAddress);
+    this.update(-1, `Validating ${isValid ? '[[;green;]PASS]' : '[[;red;]ERROR]'}`)
+    this.echo('Checking ownable on the current pool ...');
+    const isOwn = await account(this).isMyAddress(shieldedAddress);
+    this.update(-1, `Checking ownable on the current pool ${isValid ? '[[;green;]YES]' : '[[;red;]NO]'}`)
+
     this.echo('Parsing address...');
     try {
         const components = await account(this).zkAddressInfo(shieldedAddress);
         this.update(-1, 'Parsing address... [[;green;]OK]');
         this.echo(`Address format:    [[;white;]${components.format}]`);
         this.echo(`Is it derived from my SK:    ${components.derived_from_our_sk ? '[[;green;]YES]' : '[[;white;]NO]'}`);
-        const isValid = await account(this).verifyShieldedAddress(shieldedAddress);
         this.echo(`Is it valid on current pool: ${isValid ? '[[;green;]YES]' : '[[;red;]NO]'}`);
         try {
             const poolId = BigInt(components.pool_id);

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -115,7 +115,7 @@ export async function shieldedAddressInfo(shieldedAddress: string) {
     this.update(-1, `Validating ${isValid ? '[[;green;]PASS]' : '[[;red;]ERROR]'}`)
     this.echo('Checking ownable on the current pool ...');
     const isOwn = await account(this).isMyAddress(shieldedAddress);
-    this.update(-1, `Checking ownable on the current pool ${isValid ? '[[;green;]YES]' : '[[;red;]NO]'}`)
+    this.update(-1, `Checking ownable on the current pool ${isOwn ? '[[;green;]YES]' : '[[;red;]NO]'}`)
 
     this.echo('Parsing address...');
     try {

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -1,4 +1,4 @@
-import { Chains, Pools, SnarkConfigParams, Parameters } from 'zkbob-client-js';
+import { Chains, Pools, SnarkConfigParams, Parameters, ZkAddressPrefix } from 'zkbob-client-js';
 
 export interface TokenMigrationConfig {
     tokenAddress: string;
@@ -10,6 +10,7 @@ export interface ConsoleConfig {
     defaultPool: string;
     pools: Pools;
     chains: Chains;
+    extraPrefixes?: ZkAddressPrefix[];
     globalSnarks?: SnarkConfigParams;
     snarkParamsSet?: Parameters;
     blockExplorerUrls: {[chainId: string]: {tx: string, address: string} };

--- a/yarn.lock
+++ b/yarn.lock
@@ -8216,11 +8216,15 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-"libzkbob-rs-wasm-web-mt@file:../libzkbob-rs/libzkbob-rs-wasm/web-mt":
-  version "1.6.0"
+libzkbob-rs-wasm-web-mt@1.6.0-beta2:
+  version "1.6.0-beta2"
+  resolved "https://registry.yarnpkg.com/libzkbob-rs-wasm-web-mt/-/libzkbob-rs-wasm-web-mt-1.6.0-beta2.tgz#a324d891d4c0418d185d64aba06a126d7e626cab"
+  integrity sha512-BKXR/Gsl0uGhjWGhiLhDJ/ckq4+cnNgjxVGARWkXyRRXyHzUNBL9VHf4HQwxNVwOK/Vl3rRTA0A3wukOpXL5Qg==
 
-"libzkbob-rs-wasm-web@file:../libzkbob-rs/libzkbob-rs-wasm/web":
-  version "1.6.0"
+libzkbob-rs-wasm-web@1.6.0-beta2:
+  version "1.6.0-beta2"
+  resolved "https://registry.yarnpkg.com/libzkbob-rs-wasm-web/-/libzkbob-rs-wasm-web-1.6.0-beta2.tgz#bb3b87758efb7082fcb2ee0fce5a0da85119cd99"
+  integrity sha512-XbR7x7kcYAJIEVPa+HppkfpWvbgX2pSB5fjSfUN16c5UUwY+ahrmqKpTBenPF4HvhrglmBpworQjCWo8d2HcrQ==
 
 lie@3.1.1:
   version "3.1.1"
@@ -13070,8 +13074,10 @@ yocto-queue@^0.1.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
-"zkbob-client-js@file:../zkbob-client-js":
-  version "5.4.0"
+zkbob-client-js@5.5.0-beta1:
+  version "5.5.0-beta1"
+  resolved "https://registry.yarnpkg.com/zkbob-client-js/-/zkbob-client-js-5.5.0-beta1.tgz#b24d9d456817a5a3aab2fe77962499132dc30ba2"
+  integrity sha512-SUS58kxBRPLIi+M34V+uz25csLQwE70IRzCcXf+5697CG8GJ5bPSGu2EtNBh0HzAOh4AAbdkXBZ+xILr3dFxWw==
   dependencies:
     "@ethereumjs/util" "^8.0.2"
     "@graphprotocol/client-cli" "3.0.0"
@@ -13084,8 +13090,8 @@ yocto-queue@^0.1.0:
     graphql "16.7.1"
     hdwallet-babyjub "^0.0.2"
     idb "^7.0.0"
-    libzkbob-rs-wasm-web "file:../../Library/Caches/Yarn/v6/npm-zkbob-client-js-5.4.0-bfa0e765-748f-4314-9b5c-257977418d17-1700084725196/node_modules/libzkbob-rs/libzkbob-rs-wasm/web"
-    libzkbob-rs-wasm-web-mt "file:../../Library/Caches/Yarn/v6/npm-zkbob-client-js-5.4.0-bfa0e765-748f-4314-9b5c-257977418d17-1700084725196/node_modules/libzkbob-rs/libzkbob-rs-wasm/web-mt"
+    libzkbob-rs-wasm-web "1.6.0-beta2"
+    libzkbob-rs-wasm-web-mt "1.6.0-beta2"
     promise-retry "^2.0.1"
     promise-throttle "^1.1.2"
     regenerator-runtime "^0.13.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8216,15 +8216,11 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-libzkbob-rs-wasm-web-mt@1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/libzkbob-rs-wasm-web-mt/-/libzkbob-rs-wasm-web-mt-1.5.0.tgz#6a88fe3fdfcd0fe856fd791fa0976bdde2fea34b"
-  integrity sha512-2uwwE5mm32ITMvYgW3uPsPXLrPVutnpYB003wzDzMbPfF2EBjP1kh+sQwPUDmEl+ic4OSTXU/q3sdkWWmhUhRQ==
+"libzkbob-rs-wasm-web-mt@file:../libzkbob-rs/libzkbob-rs-wasm/web-mt":
+  version "1.6.0"
 
-libzkbob-rs-wasm-web@1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/libzkbob-rs-wasm-web/-/libzkbob-rs-wasm-web-1.5.0.tgz#41c2b0a51a9283a96457bd5439cfeed27f866913"
-  integrity sha512-QlnFMNzqjFakkIDrST4kmOdr+OikMZVZoOi2B73F/kb/3elcPSA5vAjYM/AdmB3+Ojty4ZrQW1GnsFWJrebF5w==
+"libzkbob-rs-wasm-web@file:../libzkbob-rs/libzkbob-rs-wasm/web":
+  version "1.6.0"
 
 lie@3.1.1:
   version "3.1.1"
@@ -13088,8 +13084,8 @@ yocto-queue@^0.1.0:
     graphql "16.7.1"
     hdwallet-babyjub "^0.0.2"
     idb "^7.0.0"
-    libzkbob-rs-wasm-web "1.5.0"
-    libzkbob-rs-wasm-web-mt "1.5.0"
+    libzkbob-rs-wasm-web "file:../../Library/Caches/Yarn/v6/npm-zkbob-client-js-5.4.0-bfa0e765-748f-4314-9b5c-257977418d17-1700084725196/node_modules/libzkbob-rs/libzkbob-rs-wasm/web"
+    libzkbob-rs-wasm-web-mt "file:../../Library/Caches/Yarn/v6/npm-zkbob-client-js-5.4.0-bfa0e765-748f-4314-9b5c-257977418d17-1700084725196/node_modules/libzkbob-rs/libzkbob-rs-wasm/web-mt"
     promise-retry "^2.0.1"
     promise-throttle "^1.1.2"
     regenerator-runtime "^0.13.9"


### PR DESCRIPTION
Now the console supports configuring address prefixes (the prefixes cannot overlap with hardcoded ones in the client library; otherwise they will be ignored).

To introduce a new address prefix add the optional field extraPrefixes to the config, as shown in the example below:
```
"extraPrefixes": [
        {
            "poolId": 123,
            "prefix": "zkbob_superpool"
        },
        {
            "poolId": 456,
            "prefix": "zkbober"
        }
    ],
```

Deployed console: https://console.thgkjlr.website/

Associated PRs:
- https://github.com/zkBob/libzkbob-rs/pull/77
- https://github.com/zkBob/zkbob-client-js/pull/172